### PR TITLE
Add authentication to Client app

### DIFF
--- a/Client/src/app/app.component.ts
+++ b/Client/src/app/app.component.ts
@@ -1,10 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { MJAuthBase } from '@memberjunction/ng-auth-services';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'Client';
+  authBase: MJAuthBase;
+
+  constructor(authBase: MJAuthBase) {
+    this.authBase = authBase;
+  }
+
+  ngOnInit(): void {
+    this.setupAuth();
+  }
+
+  setupAuth(): void {
+    this.authBase.checkUserClaims().subscribe((isAuthenticated: boolean) => {
+      if (!isAuthenticated) {
+        this.handleLogin();
+      }
+    });
+  }
+
+  handleLogin(): void {
+    this.authBase.login().subscribe(() => {
+      // Handle post-login actions here
+    });
+  }
 }

--- a/Client/src/app/app.module.ts
+++ b/Client/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { MJAuthBase } from '@memberjunction/ng-auth-services';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -17,7 +18,7 @@ import { HomeComponent } from './home/home.component';
     ReactiveFormsModule,
     AppRoutingModule,
   ],
-  providers: [provideHttpClient(withInterceptorsFromDi())],
+  providers: [provideHttpClient(withInterceptorsFromDi()), MJAuthBase],
   bootstrap: [AppComponent],
 })
 export class AppModule {}


### PR DESCRIPTION
Add authentication setup and login handling to `AppComponent`.

* **AppComponent Changes**
  - Import `MJAuthBase` from `@memberjunction/ng-auth-services`.
  - Add `authBase` property to the `AppComponent` class.
  - Add `setupAuth` method to the `AppComponent` class to check user claims and handle login if not authenticated.
  - Add `handleLogin` method to the `AppComponent` class to handle post-login actions.
  - Call `setupAuth` method in the `ngOnInit` lifecycle hook.

* **AppModule Changes**
  - Import `MJAuthBase` from `@memberjunction/ng-auth-services`.
  - Add `MJAuthBase` to the providers array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prathameshks/copilot-workspace-testing/pull/2?shareId=3618e570-df7c-42bc-be8c-5f2f4e962100).